### PR TITLE
Update subject segmentation outputs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -92,12 +92,12 @@ jobs:
           docker run --rm \
             -v ${{ env.DATA }}:/test_data \
             -v ./outputs:/outputs \
-            -v ./outputs/working_dir:/work \
+            -v ./outputs/atlases:/atlases \
             ${{env.USER_NAME}}/${{env.REPO_NAME}} \
             /test_data/ds000017-fmriprep22.0.1-downsampled-nosurface \
             /outputs \
             participant \
-            -w /work \
+            -a /atlases \
             --atlas ${{ matrix.atlas }} \
             --participant_label 1 \
             --reindex-bids

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -71,7 +71,7 @@ jobs:
     needs: [download-test-data, docker-build]
     strategy:
       matrix:
-        atlas: ['Schaefer20187Networks', 'MIST', 'DiFuMo', 'HarvardOxfordCortical', 'HarvardOxfordCorticalSymmetricSplit', 'HarvardOxfordSubcortical']
+        atlas: ['Schaefer2018', 'MIST', 'DiFuMo', 'HarvardOxfordCortical', 'HarvardOxfordCorticalSymmetricSplit', 'HarvardOxfordSubcortical']
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -1,11 +1,12 @@
 # What’s new
 
-## 0.5.1.dev
+## 0.6.0.dev
 
 **Released MONTH YEAR**
 
 ### New
 
+- [EHN] `--work-dir` is now renamed to `--atlases-dir`
 - [EHN] Add details of denoising strategy to the meta data of the time series extraction. (@htwangtw) [#144](https://github.com/bids-apps/giga_connectome/issues/144)
 
 ### Fixes
@@ -16,6 +17,9 @@
 ### Enhancements
 
 ### Changes
+
+- [EHN] Merge `atlas-` and the atlas description `desc-` into one filed `seg-` defined under 'Derivatives-Image data type' in BIDS. (@htwangtw) [#143](https://github.com/bids-apps/giga_connectome/issues/143)
+- [EHN] Working directory is now renamed as `atlases/` to reflect on the atlases directory mentioned in BEP017.
 
 ## 0.5.0
 

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -6,7 +6,8 @@
 
 ### New
 
-- [EHN] `--work-dir` is now renamed to `--atlases-dir`
+- [EHN] Default atlas `Schaefer20187Networks` is renamed to `Schaefer2018`. (@htwangtw)
+- [EHN] `--work-dir` is now renamed to `--atlases-dir`. (@htwangtw)
 - [EHN] Add details of denoising strategy to the meta data of the time series extraction. (@htwangtw) [#144](https://github.com/bids-apps/giga_connectome/issues/144)
 
 ### Fixes

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -6,8 +6,8 @@
 
 ### New
 
-- [EHN] Default atlas `Schaefer20187Networks` is renamed to `Schaefer2018`. (@htwangtw)
-- [EHN] `--work-dir` is now renamed to `--atlases-dir`. (@htwangtw)
+- [EHN] Default atlas `Schaefer20187Networks` is renamed to `Schaefer2018`. `Schaefer20187Networks` will be deprecated ub 0.7.0. (@htwangtw)
+- [EHN] `--work-dir` is now renamed to `--atlases-dir`. `--work-dir` will be deprecated ub 0.7.0. (@htwangtw)
 - [EHN] Add details of denoising strategy to the meta data of the time series extraction. (@htwangtw) [#144](https://github.com/bids-apps/giga_connectome/issues/144)
 
 ### Fixes

--- a/docs/source/outputs.md
+++ b/docs/source/outputs.md
@@ -16,12 +16,12 @@ the output will be save in `sub-<participant_id>/[ses-<ses_id>]/func`.
 For each input image (that is, preprocessed BOLD time series)
 and each atlas the following data files will be generated
 
-- a `[matches]_atlas-{atlas}_meas-PearsonCorrelation_desc-{atlas_description}{denoise_strategy}_relmat.tsv`
+- a `[matches]_seg-{atlas}{atlas_description}_meas-PearsonCorrelation_desc-denoise{denoise_strategy}_relmat.tsv`
   file that contains the correlation matrix between all the regions of the atlas
-- a `[matches]_atlas-{atlas}_desc-{atlas description}{denoise_strategy}_timeseries.tsv`
+- a `[matches]_seg-{atlas}{atlas_description}_desc-denoise{denoise_strategy}_timeseries.tsv`
   file that contains the extracted timeseries for each region of the atlas
 
-- `{atlas}` refers to the name of the atlas used (for example, `Schaefer20187Networks`)
+- `{atlas}` refers to the name of the atlas used (for example, `Schaefer2018`)
 - `{atlas_description}` refers to the sub type of atlas used (for example, `100Parcels7Networks`)
 - `{denoise_strategy}` refers to the denoise strategy passed to the command line
 
@@ -31,7 +31,7 @@ A JSON file is generated in the root of the output dataset (`meas-PearsonCorrela
 that contains metadata applicable to all `relmat.tsv` files.
 
 For each input image (that is, preprocessed BOLD time series)
-a `[matches]_atlas-{atlas}_timeseries.json`
+a `[matches]_desc-denoise{denoise_strategy}_timeseries.json`
 
 ### Example
 
@@ -43,51 +43,100 @@ a `[matches]_atlas-{atlas}_timeseries.json`
 ├── sub-1
 │   ├── ses-timepoint1
 │   │   └── func
-│   │       ├── sub-1_ses-timepoint1_task-probabilisticclassification_run-01_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_desc-100Parcels7NetworksSimple_timeseries.tsv
-│   │       ├── sub-1_ses-timepoint1_task-probabilisticclassification_run-01_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_desc-200Parcels7NetworksSimple_timeseries.tsv
-│   │       ├── sub-1_ses-timepoint1_task-probabilisticclassification_run-01_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_meas-PearsonCorrelation_desc-100Parcels7NetworksSimple_relmat.tsv
-│   │       ├── sub-1_ses-timepoint1_task-probabilisticclassification_run-01_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_meas-PearsonCorrelation_desc-200Parcels7NetworksSimple_relmat.tsv
-│   │       ├── sub-1_ses-timepoint1_task-probabilisticclassification_run-01_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_timeseries.json
-│   │       ├── sub-1_ses-timepoint1_task-probabilisticclassification_run-02_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_desc-100Parcels7NetworksSimple_timeseries.tsv
-│   │       ├── sub-1_ses-timepoint1_task-probabilisticclassification_run-02_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_desc-200Parcels7NetworksSimple_timeseries.tsv
-│   │       ├── sub-1_ses-timepoint1_task-probabilisticclassification_run-02_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_meas-PearsonCorrelation_desc-100Parcels7NetworksSimple_relmat.tsv
-│   │       ├── sub-1_ses-timepoint1_task-probabilisticclassification_run-02_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_meas-PearsonCorrelation_desc-200Parcels7NetworksSimple_relmat.tsv
-│   │       └── sub-1_ses-timepoint1_task-probabilisticclassification_run-02_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_timeseries.json
+│   │       ├── sub-1_ses-timepoint1_task-probabilisticclassification_run-01_desc-denoiseSimple_timeseries.json
+│   │       ├── sub-1_ses-timepoint1_task-probabilisticclassification_run-01_seg-Schaefer2018100Parcels7Networks_desc-denoiseSimple_report.html
+│   │       ├── sub-1_ses-timepoint1_task-probabilisticclassification_run-01_seg-Schaefer2018100Parcels7Networks_desc-denoiseSimple_timeseries.tsv
+│   │       ├── sub-1_ses-timepoint1_task-probabilisticclassification_run-01_seg-Schaefer2018100Parcels7Networks_meas-PearsonCorrelation_desc-denoiseSimple_relmat.tsv
+│   │       ├── sub-1_ses-timepoint1_task-probabilisticclassification_run-01_seg-Schaefer2018200Parcels7Networks_desc-denoiseSimple_report.html
+│   │       ├── sub-1_ses-timepoint1_task-probabilisticclassification_run-01_seg-Schaefer2018200Parcels7Networks_desc-denoiseSimple_timeseries.tsv
+│   │       ├── sub-1_ses-timepoint1_task-probabilisticclassification_run-01_seg-Schaefer2018200Parcels7Networks_meas-PearsonCorrelation_desc-denoiseSimple_relmat.tsv
+│   │       ├── sub-1_ses-timepoint1_task-probabilisticclassification_run-02_desc-denoiseSimple_timeseries.json
+│   │       ├── sub-1_ses-timepoint1_task-probabilisticclassification_run-02_seg-Schaefer2018100Parcels7Networks_desc-denoiseSimple_report.html
+│   │       ├── sub-1_ses-timepoint1_task-probabilisticclassification_run-02_seg-Schaefer2018100Parcels7Networks_desc-denoiseSimple_timeseries.tsv
+│   │       ├── sub-1_ses-timepoint1_task-probabilisticclassification_run-02_seg-Schaefer2018100Parcels7Networks_meas-PearsonCorrelation_desc-denoiseSimple_relmat.tsv
+│   │       ├── sub-1_ses-timepoint1_task-probabilisticclassification_run-02_seg-Schaefer2018200Parcels7Networks_desc-denoiseSimple_report.html
+│   │       ├── sub-1_ses-timepoint1_task-probabilisticclassification_run-02_seg-Schaefer2018200Parcels7Networks_desc-denoiseSimple_timeseries.tsv
+│   │       └── sub-1_ses-timepoint1_task-probabilisticclassification_run-02_seg-Schaefer2018200Parcels7Networks_meas-PearsonCorrelation_desc-denoiseSimple_relmat.tsv
 │   └── ses-timepoint2
 │       └── func
-│           ├── sub-1_ses-timepoint2_task-probabilisticclassification_run-01_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_desc-100Parcels7NetworksSimple_timeseries.tsv
-│           ├── sub-1_ses-timepoint2_task-probabilisticclassification_run-01_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_desc-200Parcels7NetworksSimple_timeseries.tsv
-│           ├── sub-1_ses-timepoint2_task-probabilisticclassification_run-01_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_meas-PearsonCorrelation_desc-100Parcels7NetworksSimple_relmat.tsv
-│           ├── sub-1_ses-timepoint2_task-probabilisticclassification_run-01_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_meas-PearsonCorrelation_desc-200Parcels7NetworksSimple_relmat.tsv
-│           ├── sub-1_ses-timepoint2_task-probabilisticclassification_run-01_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_timeseries.json
-│           ├── sub-1_ses-timepoint2_task-probabilisticclassification_run-02_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_desc-100Parcels7NetworksSimple_timeseries.tsv
-│           ├── sub-1_ses-timepoint2_task-probabilisticclassification_run-02_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_desc-200Parcels7NetworksSimple_timeseries.tsv
-│           ├── sub-1_ses-timepoint2_task-probabilisticclassification_run-02_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_meas-PearsonCorrelation_desc-100Parcels7NetworksSimple_relmat.tsv
-│           ├── sub-1_ses-timepoint2_task-probabilisticclassification_run-02_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_meas-PearsonCorrelation_desc-200Parcels7NetworksSimple_relmat.tsv
-│           └── sub-1_ses-timepoint2_task-probabilisticclassification_run-02_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_timeseries.json
+│           ├── sub-1_ses-timepoint2_task-probabilisticclassification_run-01_desc-denoiseSimple_timeseries.json
+│           ├── sub-1_ses-timepoint2_task-probabilisticclassification_run-01_seg-Schaefer2018100Parcels7Networks_desc-denoiseSimple_report.html
+│           ├── sub-1_ses-timepoint2_task-probabilisticclassification_run-01_seg-Schaefer2018100Parcels7Networks_desc-denoiseSimple_timeseries.tsv
+│           ├── sub-1_ses-timepoint2_task-probabilisticclassification_run-01_seg-Schaefer2018100Parcels7Networks_meas-PearsonCorrelation_desc-denoiseSimple_relmat.tsv
+│           ├── sub-1_ses-timepoint2_task-probabilisticclassification_run-01_seg-Schaefer2018200Parcels7Networks_desc-denoiseSimple_report.html
+│           ├── sub-1_ses-timepoint2_task-probabilisticclassification_run-01_seg-Schaefer2018200Parcels7Networks_desc-denoiseSimple_timeseries.tsv
+│           ├── sub-1_ses-timepoint2_task-probabilisticclassification_run-01_seg-Schaefer2018200Parcels7Networks_meas-PearsonCorrelation_desc-denoiseSimple_relmat.tsv
+│           ├── sub-1_ses-timepoint2_task-probabilisticclassification_run-02_desc-denoiseSimple_timeseries.json
+│           ├── sub-1_ses-timepoint2_task-probabilisticclassification_run-02_seg-Schaefer2018100Parcels7Networks_desc-denoiseSimple_report.html
+│           ├── sub-1_ses-timepoint2_task-probabilisticclassification_run-02_seg-Schaefer2018100Parcels7Networks_desc-denoiseSimple_timeseries.tsv
+│           ├── sub-1_ses-timepoint2_task-probabilisticclassification_run-02_seg-Schaefer2018100Parcels7Networks_meas-PearsonCorrelation_desc-denoiseSimple_relmat.tsv
+│           ├── sub-1_ses-timepoint2_task-probabilisticclassification_run-02_seg-Schaefer2018200Parcels7Networks_desc-denoiseSimple_report.html
+│           ├── sub-1_ses-timepoint2_task-probabilisticclassification_run-02_seg-Schaefer2018200Parcels7Networks_desc-denoiseSimple_timeseries.tsv
+│           └── sub-1_ses-timepoint2_task-probabilisticclassification_run-02_seg-Schaefer2018200Parcels7Networks_meas-PearsonCorrelation_desc-denoiseSimple_relmat.tsv
 └── sub-2
-    ├── ses-timepoint1
-    │   └── func
-    │       ├── sub-2_ses-timepoint1_task-probabilisticclassification_run-01_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_desc-100Parcels7NetworksSimple_timeseries.tsv
-    │       ├── sub-2_ses-timepoint1_task-probabilisticclassification_run-01_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_desc-200Parcels7NetworksSimple_timeseries.tsv
-    │       ├── sub-2_ses-timepoint1_task-probabilisticclassification_run-01_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_meas-PearsonCorrelation_desc-100Parcels7NetworksSimple_relmat.tsv
-    │       ├── sub-2_ses-timepoint1_task-probabilisticclassification_run-01_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_meas-PearsonCorrelation_desc-200Parcels7NetworksSimple_relmat.tsv
-    │       ├── sub-2_ses-timepoint1_task-probabilisticclassification_run-01_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_timeseries.json
-    │       ├── sub-2_ses-timepoint1_task-probabilisticclassification_run-02_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_desc-100Parcels7NetworksSimple_timeseries.tsv
-    │       ├── sub-2_ses-timepoint1_task-probabilisticclassification_run-02_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_desc-200Parcels7NetworksSimple_timeseries.tsv
-    │       ├── sub-2_ses-timepoint1_task-probabilisticclassification_run-02_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_meas-PearsonCorrelation_desc-100Parcels7NetworksSimple_relmat.tsv
-    │       ├── sub-2_ses-timepoint1_task-probabilisticclassification_run-02_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_meas-PearsonCorrelation_desc-200Parcels7NetworksSimple_relmat.tsv
-    │       └── sub-2_ses-timepoint1_task-probabilisticclassification_run-02_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_timeseries.json
-    └── ses-timepoint2
-        └── func
-            ├── sub-2_ses-timepoint2_task-probabilisticclassification_run-01_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_desc-100Parcels7NetworksSimple_timeseries.tsv
-            ├── sub-2_ses-timepoint2_task-probabilisticclassification_run-01_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_desc-200Parcels7NetworksSimple_timeseries.tsv
-            ├── sub-2_ses-timepoint2_task-probabilisticclassification_run-01_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_meas-PearsonCorrelation_desc-100Parcels7NetworksSimple_relmat.tsv
-            ├── sub-2_ses-timepoint2_task-probabilisticclassification_run-01_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_meas-PearsonCorrelation_desc-200Parcels7NetworksSimple_relmat.tsv
-            ├── sub-2_ses-timepoint2_task-probabilisticclassification_run-01_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_timeseries.json
-            ├── sub-2_ses-timepoint2_task-probabilisticclassification_run-02_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_desc-100Parcels7NetworksSimple_timeseries.tsv
-            ├── sub-2_ses-timepoint2_task-probabilisticclassification_run-02_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_desc-200Parcels7NetworksSimple_timeseries.tsv
-            ├── sub-2_ses-timepoint2_task-probabilisticclassification_run-02_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_meas-PearsonCorrelation_desc-100Parcels7NetworksSimple_relmat.tsv
-            ├── sub-2_ses-timepoint2_task-probabilisticclassification_run-02_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_meas-PearsonCorrelation_desc-200Parcels7NetworksSimple_relmat.tsv
-            └── sub-2_ses-timepoint2_task-probabilisticclassification_run-02_space-MNI152NLin2009cAsym_res-2_atlas-Schaefer20187Networks_timeseries.json
+    ├── ses-timepoint1
+    │   └── func
+    │       ├── sub-2_ses-timepoint1_task-probabilisticclassification_run-01_desc-denoiseSimple_timeseries.json
+    │       ├── sub-2_ses-timepoint1_task-probabilisticclassification_run-01_seg-Schaefer2018100Parcels7Networks_desc-denoiseSimple_report.html
+    │       ├── sub-2_ses-timepoint1_task-probabilisticclassification_run-01_seg-Schaefer2018100Parcels7Networks_desc-denoiseSimple_timeseries.tsv
+    │       ├── sub-2_ses-timepoint1_task-probabilisticclassification_run-01_seg-Schaefer2018100Parcels7Networks_meas-PearsonCorrelation_desc-denoiseSimple_relmat.tsv
+    │       ├── sub-2_ses-timepoint1_task-probabilisticclassification_run-01_seg-Schaefer2018200Parcels7Networks_desc-denoiseSimple_report.html
+    │       ├── sub-2_ses-timepoint1_task-probabilisticclassification_run-01_seg-Schaefer2018200Parcels7Networks_desc-denoiseSimple_timeseries.tsv
+    │       ├── sub-2_ses-timepoint1_task-probabilisticclassification_run-01_seg-Schaefer2018200Parcels7Networks_meas-PearsonCorrelation_desc-denoiseSimple_relmat.tsv
+    │       ├── sub-2_ses-timepoint1_task-probabilisticclassification_run-02_desc-denoiseSimple_timeseries.json
+    │       ├── sub-2_ses-timepoint1_task-probabilisticclassification_run-02_seg-Schaefer2018100Parcels7Networks_desc-denoiseSimple_report.html
+    │       ├── sub-2_ses-timepoint1_task-probabilisticclassification_run-02_seg-Schaefer2018100Parcels7Networks_desc-denoiseSimple_timeseries.tsv
+    │       ├── sub-2_ses-timepoint1_task-probabilisticclassification_run-02_seg-Schaefer2018100Parcels7Networks_meas-PearsonCorrelation_desc-denoiseSimple_relmat.tsv
+    │       ├── sub-2_ses-timepoint1_task-probabilisticclassification_run-02_seg-Schaefer2018200Parcels7Networks_desc-denoiseSimple_report.html
+    │       ├── sub-2_ses-timepoint1_task-probabilisticclassification_run-02_seg-Schaefer2018200Parcels7Networks_desc-denoiseSimple_timeseries.tsv
+    │       └── sub-2_ses-timepoint1_task-probabilisticclassification_run-02_seg-Schaefer2018200Parcels7Networks_meas-PearsonCorrelation_desc-denoiseSimple_relmat.tsv
+    └── ses-timepoint2
+        └── func
+            ├── sub-2_ses-timepoint2_task-probabilisticclassification_run-01_desc-denoiseSimple_timeseries.json
+            ├── sub-2_ses-timepoint2_task-probabilisticclassification_run-01_seg-Schaefer2018100Parcels7Networks_desc-denoiseSimple_report.html
+            ├── sub-2_ses-timepoint2_task-probabilisticclassification_run-01_seg-Schaefer2018100Parcels7Networks_desc-denoiseSimple_timeseries.tsv
+            ├── sub-2_ses-timepoint2_task-probabilisticclassification_run-01_seg-Schaefer2018100Parcels7Networks_meas-PearsonCorrelation_desc-denoiseSimple_relmat.tsv
+            ├── sub-2_ses-timepoint2_task-probabilisticclassification_run-01_seg-Schaefer2018200Parcels7Networks_desc-denoiseSimple_report.html
+            ├── sub-2_ses-timepoint2_task-probabilisticclassification_run-01_seg-Schaefer2018200Parcels7Networks_desc-denoiseSimple_timeseries.tsv
+            ├── sub-2_ses-timepoint2_task-probabilisticclassification_run-01_seg-Schaefer2018200Parcels7Networks_meas-PearsonCorrelation_desc-denoiseSimple_relmat.tsv
+            ├── sub-2_ses-timepoint2_task-probabilisticclassification_run-02_desc-denoiseSimple_timeseries.json
+            ├── sub-2_ses-timepoint2_task-probabilisticclassification_run-02_seg-Schaefer2018100Parcels7Networks_desc-denoiseSimple_report.html
+            ├── sub-2_ses-timepoint2_task-probabilisticclassification_run-02_seg-Schaefer2018100Parcels7Networks_desc-denoiseSimple_timeseries.tsv
+            ├── sub-2_ses-timepoint2_task-probabilisticclassification_run-02_seg-Schaefer2018100Parcels7Networks_meas-PearsonCorrelation_desc-denoiseSimple_relmat.tsv
+            ├── sub-2_ses-timepoint2_task-probabilisticclassification_run-02_seg-Schaefer2018200Parcels7Networks_desc-denoiseSimple_report.html
+            ├── sub-2_ses-timepoint2_task-probabilisticclassification_run-02_seg-Schaefer2018200Parcels7Networks_desc-denoiseSimple_timeseries.tsv
+            └── sub-2_ses-timepoint2_task-probabilisticclassification_run-02_seg-Schaefer2018200Parcels7Networks_meas-PearsonCorrelation_desc-denoiseSimple_relmat.tsv
+```
+
+
+## Atlases
+
+The merged grey matter masks per subject and the atlases resampled to the individual EPI data are in the directory specified at `--atlases_dir`.
+
+For each subject and each atlas the following data files will be generated
+
+- a `sub-<sub>_space-MNI152NLin2009cAsym_res-2_label-GM_mask.nii.gz`
+  Grey matter mask in the dedicated space for a given subject,
+  created from merging all the EPI brain masks of a given subject,
+  and converges with the grey matter mask of the given space.
+- `sub-<sub>_seg-{atlas}{atlas_description}_[dseg|probseg].nii.gz`
+  files where the atlas were sampled to `sub-<sub>_space-MNI152NLin2009cAsym_res-2_label-GM_mask.nii.gz`
+  for each individual.
+
+- `{atlas}` refers to the name of the atlas used (for example, `Schaefer2018`)
+- `{atlas_description}` refers to the sub type of atlas used (for example, `100Parcels7Networks`)
+
+### Example
+
+```
+└── sub-1
+    └── func
+        ├── sub-1_seg-Schaefer2018100Parcels7Networks_dseg.nii.gz
+        ├── sub-1_seg-Schaefer2018200Parcels7Networks_dseg.nii.gz
+        ├── sub-1_seg-Schaefer2018300Parcels7Networks_dseg.nii.gz
+        ├── sub-1_seg-Schaefer2018400Parcels7Networks_dseg.nii.gz
+        ├── sub-1_seg-Schaefer2018500Parcels7Networks_dseg.nii.gz
+        ├── sub-1_seg-Schaefer2018600Parcels7Networks_dseg.nii.gz
+        ├── sub-1_seg-Schaefer2018800Parcels7Networks_dseg.nii.gz
+        └── sub-1_space-MNI152NLin2009cAsym_res-2_label-GM_mask.nii.gz
 ```

--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -47,7 +47,7 @@ An example using Apptainer (formerly known as Singularity):
 ```bash
 FMRIPREP_DIR=/path/to/fmriprep_output
 OUTPUT_DIR=/path/to/connectom_output
-WORKING_DIR=/path/to/working_dir
+ATLASES_DIR=/path/to/atlases
 DENOISE_CONFIG=/path/to/denoise_config.json
 
 GIGA_CONNECTOME=/path/to/giga-connectome.simg
@@ -55,10 +55,10 @@ GIGA_CONNECTOME=/path/to/giga-connectome.simg
 apptainer run \
     --bind ${FMRIPREP_DIR}:/data/input \
     --bind ${OUTPUT_DIR}:/data/output \
-    --bind ${WORKING_DIR}:/data/working \
+    --bind ${ATLASES_DIR}:/data/atlases \
     --bind ${DENOISE_CONFIG}:/data/denoise_config.json \
     ${GIGA_CONNECTOME} \
-    -w /data/working \
+    -a /data/atlases \
     --denoise-strategy /data/denoise_config.json \
     /data/input \
     /data/output \
@@ -128,7 +128,7 @@ An example using Apptainer (formerly known as Singularity):
 ```bash
 FMRIPREP_DIR=/path/to/fmriprep_output
 OUTPUT_DIR=/path/to/connectom_output
-WORKING_DIR=/path/to/working_dir
+ATLASES_DIR=/path/to/atlases
 ATLAS_CONFIG=/path/to/atlas_config.json
 
 GIGA_CONNECTOME=/path/to/giga-connectome.simg
@@ -138,10 +138,10 @@ export APPTAINERENV_TEMPLATEFLOW_HOME=/data/atlas
 apptainer run \
     --bind ${FMRIPREP_DIR}:/data/input \
     --bind ${OUTPUT_DIR}:/data/output \
-    --bind ${WORKING_DIR}:/data/working \
+    --bind ${ATLASES_DIR}:/data/atlases \
     --bind ${ATLAS_CONFIG}:/data/atlas_config.json \
     ${GIGA_CONNECTOME} \
-    -w /data/working \
+    -s /data/atlases \
     --atlas /data/atlas_config.json \
     /data/input \
     /data/output \

--- a/giga_connectome/atlas.py
+++ b/giga_connectome/atlas.py
@@ -36,6 +36,7 @@ deprecations = {
     "Schaefer20187Networks": ("Schaefer2018", "0.7.0"),
 }
 
+
 def load_atlas_setting(
     atlas: str | Path | dict[str, Any],
 ) -> ATLAS_SETTING_TYPE:

--- a/giga_connectome/atlas.py
+++ b/giga_connectome/atlas.py
@@ -177,7 +177,7 @@ def _check_altas_config(
     KeyError
         atlas configuration not containing the correct keys.
     """
-    if atlas in deprecations:
+    if isinstance(atlas, str) and atlas in deprecations:
         new_name, version = deprecations[atlas]
         gc_log.warning(
             f"{atlas} has been deprecated and will be removed in "

--- a/giga_connectome/data/atlas/Schaefer2018.json
+++ b/giga_connectome/data/atlas/Schaefer2018.json
@@ -1,5 +1,5 @@
 {
-    "name": "Schaefer20187Networks",
+    "name": "Schaefer2018",
     "parameters": {
         "atlas": "Schaefer2018",
         "template": "MNI152NLin2009cAsym",

--- a/giga_connectome/mask.py
+++ b/giga_connectome/mask.py
@@ -27,7 +27,7 @@ gc_log = gc_logger()
 
 
 def generate_gm_mask_atlas(
-    working_dir: Path,
+    atlases_dir: Path,
     atlas: ATLAS_SETTING_TYPE,
     template: str,
     masks: list[BIDSImageFile],
@@ -36,7 +36,7 @@ def generate_gm_mask_atlas(
     # check masks; isolate this part and make sure to make it a validate
     # templateflow template with a config file
     subject, _, _ = utils.parse_bids_name(masks[0].path)
-    subject_mask_dir = working_dir / subject / "func"
+    subject_mask_dir = atlases_dir / subject / "func"
     subject_mask_dir.mkdir(exist_ok=True, parents=True)
     target_subject_mask_file_name: str = utils.output_filename(
         source_file=masks[0].path,

--- a/giga_connectome/postprocess.py
+++ b/giga_connectome/postprocess.py
@@ -184,7 +184,7 @@ def run_postprocessing_dataset(
                     suffix="relmat",
                     extension="tsv",
                     strategy=strategy["name"],
-                    desc=desc,
+                    atlas_desc=desc,
                 )
                 utils.check_path(relmat_filename)
                 df = pd.DataFrame(correlation_matrix)
@@ -197,7 +197,7 @@ def run_postprocessing_dataset(
                     suffix="timeseries",
                     extension="tsv",
                     strategy=strategy["name"],
-                    desc=desc,
+                    atlas_desc=desc,
                 )
                 utils.check_path(timeseries_filename)
                 df = pd.DataFrame(time_series_atlas)
@@ -210,7 +210,7 @@ def run_postprocessing_dataset(
                     suffix="report",
                     extension="html",
                     strategy=strategy["name"],
-                    desc=desc,
+                    atlas_desc=desc,
                 )
                 report.save_as_html(report_filename)
 

--- a/giga_connectome/run.py
+++ b/giga_connectome/run.py
@@ -51,20 +51,20 @@ def global_parser() -> argparse.ArgumentParser:
         nargs="+",
     )
     parser.add_argument(
-        "-w",
-        "--work-dir",
+        "-a",
+        "--atlases-dir",
         action="store",
         type=Path,
-        default=Path("work").absolute(),
-        help="Path where intermediate results should be stored.",
+        default=Path("atlases").absolute(),
+        help="Path where subject specific segmentations are stored.",
     )
     parser.add_argument(
         "--atlas",
         help="The choice of atlas for time series extraction. Default atlas "
         f"choices are: {preset_atlas}. User can pass "
         "a path to a json file containing configuration for their own choice "
-        "of atlas. The default is 'Schaefer20187Networks'.",
-        default="Schaefer20187Networks",
+        "of atlas. The default is 'Schaefer2018'.",
+        default="Schaefer2018",
     )
     parser.add_argument(
         "--denoise-strategy",

--- a/giga_connectome/run.py
+++ b/giga_connectome/run.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-
+from typing import Any
 import argparse
 from pathlib import Path
 from typing import Sequence
@@ -13,19 +13,27 @@ gc_log = gc_logger()
 
 preset_atlas = get_atlas_labels()
 deprecations = {
-    # parser attribute name: (replacement flag, version slated to be removed in)
-    'work-dir': ('--atlases-dir', '0.7.0'),
+    # parser attribute name:
+    # (replacement flag, version slated to be removed in)
+    "work-dir": ("--atlases-dir", "0.7.0"),
 }
 
+
 class DeprecatedAction(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: str | Sequence[Any] | None,
+        option_string: str | None = None,
+    ) -> None:
         new_opt, rem_vers = deprecations.get(self.dest, (None, None))
         msg = (
-            f"{self.option_strings} has been deprecated and will be removed in "
-            f"{rem_vers or 'a later version'}."
+            f"{self.option_strings} has been deprecated and will be removed "
+            f"in {rem_vers or 'a later version'}."
         )
         if new_opt:
-            msg += f' Please use `{new_opt}` instead.'
+            msg += f" Please use `{new_opt}` instead."
         gc_log.warning(msg)
         delattr(namespace, self.dest)
 

--- a/giga_connectome/tests/test_atlas.py
+++ b/giga_connectome/tests/test_atlas.py
@@ -1,7 +1,9 @@
 from giga_connectome.atlas import load_atlas_setting
+import pytest
+from pkg_resources import resource_filename
 
 
-def test_load_atlas_setting(capsys):
+def test_load_atlas_setting():
     # use Schaefer2018 when updating 0.7.0
     atlas_config = load_atlas_setting("Schaefer20187Networks")
     assert atlas_config["name"] == "Schaefer2018"
@@ -9,3 +11,7 @@ def test_load_atlas_setting(capsys):
     assert atlas_config["name"] == "Schaefer2018"
     atlas_config = load_atlas_setting("HarvardOxfordCortical")
     assert atlas_config["name"] == "HarvardOxfordCortical"
+    pytest.raises(FileNotFoundError, load_atlas_setting, "blah")
+    json_path = resource_filename("giga_connectome", "data/atlas/DiFuMo.json")
+    atlas_config = load_atlas_setting(json_path)
+    assert atlas_config["name"] == "DiFuMo"

--- a/giga_connectome/tests/test_atlas.py
+++ b/giga_connectome/tests/test_atlas.py
@@ -1,7 +1,10 @@
 from giga_connectome.atlas import load_atlas_setting
 
 
-def test_load_atlas_setting():
+def test_load_atlas_setting(capsys):
+    # use Schaefer2018 when updating 0.7.0
+    atlas_config = load_atlas_setting("Schaefer20187Networks")
+    assert atlas_config["name"] == "Schaefer2018"
     atlas_config = load_atlas_setting("Schaefer2018")
     assert atlas_config["name"] == "Schaefer2018"
     atlas_config = load_atlas_setting("HarvardOxfordCortical")

--- a/giga_connectome/tests/test_atlas.py
+++ b/giga_connectome/tests/test_atlas.py
@@ -2,7 +2,7 @@ from giga_connectome.atlas import load_atlas_setting
 
 
 def test_load_atlas_setting():
-    atlas_config = load_atlas_setting("Schaefer20187Networks")
-    assert atlas_config["name"] == "Schaefer20187Networks"
+    atlas_config = load_atlas_setting("Schaefer2018")
+    assert atlas_config["name"] == "Schaefer2018"
     atlas_config = load_atlas_setting("HarvardOxfordCortical")
     assert atlas_config["name"] == "HarvardOxfordCortical"

--- a/giga_connectome/tests/test_cli.py
+++ b/giga_connectome/tests/test_cli.py
@@ -39,7 +39,7 @@ def test_smoke(tmp_path, capsys):
         "data/test_data/ds000017-fmriprep22.0.1-downsampled-nosurface",
     )
     output_dir = tmp_path / "output"
-    work_dir = tmp_path / "output/work"
+    atlases_dir = tmp_path / "atlases"
 
     if not Path(output_dir).exists:
         Path(output_dir).mkdir()
@@ -49,9 +49,9 @@ def test_smoke(tmp_path, capsys):
             "--participant_label",
             "1",
             "-w",
-            str(work_dir),
+            str(atlases_dir),
             "--atlas",
-            "Schaefer20187Networks",
+            "Schaefer2018",
             "--denoise-strategy",
             "simple",
             "--reindex-bids",
@@ -66,27 +66,26 @@ def test_smoke(tmp_path, capsys):
 
     base = (
         "sub-1_ses-timepoint1_task-probabilisticclassification"
-        "_run-01_space-MNI152NLin2009cAsym_res-2"
-        "_atlas-Schaefer20187Networks"
+        "_run-01_seg-Schaefer2018100Parcels7Networks"
     )
-
+    ts_base = (
+        "sub-1_ses-timepoint1_task-probabilisticclassification"
+        "_run-01_desc-denoiseSimple"
+    )
     relmat_file = output_folder / (
-        base
-        + "_meas-PearsonCorrelation"
-        + "_desc-100Parcels7NetworksSimple_relmat.tsv"
+        base + "_meas-PearsonCorrelation" + "_desc-denoiseSimple_relmat.tsv"
     )
     assert relmat_file.exists()
     relmat = pd.read_csv(relmat_file, sep="\t")
     assert len(relmat) == 100
-
-    json_file = relmat_file = output_folder / (base + "_timeseries.json")
+    json_file = relmat_file = output_folder / (ts_base + "_timeseries.json")
     assert json_file.exists()
     with open(json_file, "r") as f:
         content = json.load(f)
         assert content.get("SamplingFrequency") == 0.5
 
     timeseries_file = relmat_file = output_folder / (
-        base + "_desc-100Parcels7NetworksSimple_timeseries.tsv"
+        base + "_desc-denoiseSimple_timeseries.tsv"
     )
     assert timeseries_file.exists()
     timeseries = pd.read_csv(timeseries_file, sep="\t")

--- a/giga_connectome/tests/test_cli.py
+++ b/giga_connectome/tests/test_cli.py
@@ -33,7 +33,7 @@ def test_help(capsys):
 
 
 @pytest.mark.smoke
-def test_smoke(tmp_path, capsys):
+def test_smoke(tmp_path, caplog):
     bids_dir = resource_filename(
         "giga_connectome",
         "data/test_data/ds000017-fmriprep22.0.1-downsampled-nosurface",
@@ -54,7 +54,7 @@ def test_smoke(tmp_path, capsys):
             "-a",
             str(atlases_dir),
             "--atlas",
-            "Schaefer20187Networks",  # use Schaefer2018 when updating 0.7.0
+            "Schaefer2018",
             "--denoise-strategy",
             "simple",
             "--reindex-bids",
@@ -64,8 +64,7 @@ def test_smoke(tmp_path, capsys):
             "participant",
         ]
     )
-    captured = capsys.readouterr()
-    assert "has been deprecated" in captured.out.split()[0]
+    assert "has been deprecated" in caplog.text.splitlines()[0]
 
     output_folder = output_dir / "sub-1" / "ses-timepoint1" / "func"
 

--- a/giga_connectome/tests/test_cli.py
+++ b/giga_connectome/tests/test_cli.py
@@ -54,7 +54,7 @@ def test_smoke(tmp_path, capsys):
             "-a",
             str(atlases_dir),
             "--atlas",
-            "Schaefer2018",
+            "Schaefer20187Networks",  # use Schaefer2018 when updating 0.7.0
             "--denoise-strategy",
             "simple",
             "--reindex-bids",
@@ -65,7 +65,7 @@ def test_smoke(tmp_path, capsys):
         ]
     )
     captured = capsys.readouterr()
-    assert "has been deprecated" in captured.out
+    assert "has been deprecated" in captured.out.split()[0]
 
     output_folder = output_dir / "sub-1" / "ses-timepoint1" / "func"
 

--- a/giga_connectome/tests/test_cli.py
+++ b/giga_connectome/tests/test_cli.py
@@ -40,6 +40,7 @@ def test_smoke(tmp_path, capsys):
     )
     output_dir = tmp_path / "output"
     atlases_dir = tmp_path / "atlases"
+    work_dir = tmp_path / "work"
 
     if not Path(output_dir).exists:
         Path(output_dir).mkdir()
@@ -48,6 +49,8 @@ def test_smoke(tmp_path, capsys):
         [
             "--participant_label",
             "1",
+            "-w",
+            str(work_dir),
             "-a",
             str(atlases_dir),
             "--atlas",
@@ -61,6 +64,8 @@ def test_smoke(tmp_path, capsys):
             "participant",
         ]
     )
+    captured = capsys.readouterr()
+    assert "has been deprecated" in captured.out
 
     output_folder = output_dir / "sub-1" / "ses-timepoint1" / "func"
 

--- a/giga_connectome/tests/test_cli.py
+++ b/giga_connectome/tests/test_cli.py
@@ -48,7 +48,7 @@ def test_smoke(tmp_path, capsys):
         [
             "--participant_label",
             "1",
-            "-w",
+            "-a",
             str(atlases_dir),
             "--atlas",
             "Schaefer2018",

--- a/giga_connectome/tests/test_mask.py
+++ b/giga_connectome/tests/test_mask.py
@@ -6,22 +6,25 @@ from nilearn import datasets
 from giga_connectome import mask
 
 
-def test_generate_group_mask():
+def test_generate_subject_gm_mask():
     """Generate group epi grey matter mask and resample atlas."""
+    # use different subject in the test, should work the same
     data = datasets.fetch_development_fmri(n_subjects=3)
     imgs = data.func
 
-    group_epi_mask = mask.generate_group_mask(imgs)
+    group_epi_mask = mask.generate_subject_gm_mask(imgs)
     # match the post processing details: https://osf.io/wjtyq
     assert group_epi_mask.shape == (50, 59, 50)
-    diff_tpl = mask.generate_group_mask(imgs, template="MNI152NLin2009aAsym")
+    diff_tpl = mask.generate_subject_gm_mask(
+        imgs, template="MNI152NLin2009aAsym"
+    )
     assert diff_tpl.shape == (50, 59, 50)
 
     # test bad inputs
     with pytest.raises(
         ValueError, match="TemplateFlow does not supply template blah"
     ):
-        mask.generate_group_mask(imgs, template="blah")
+        mask.generate_subject_gm_mask(imgs, template="blah")
 
 
 def test_check_mask_affine():

--- a/giga_connectome/tests/test_utils.py
+++ b/giga_connectome/tests/test_utils.py
@@ -33,10 +33,15 @@ def test_check_check_filter():
     assert "dseg" in str(msg.value)
 
 
-def test_parse_bids_name():
-    subject, session, specifier = utils.parse_bids_name(
-        "sub-01_ses-ah_task-rest_run-1_space-MNIfake_res-2_desc-preproc_bold.nii.gz"
-    )
+@pytest.mark.parametrize(
+    "source_file",
+    [
+        "sub-01_ses-ah_task-rest_run-1_space-MNIfake_res-2_desc-preproc_bold.nii.gz",
+        "sub-01_ses-ah_task-rest_run-1_space-MNIfake_res-2_desc-brain_mask.nii.gz",
+    ],
+)
+def test_parse_bids_name(source_file):
+    subject, session, specifier = utils.parse_bids_name(source_file)
     assert subject == "sub-01"
     assert session == "ses-ah"
     assert specifier == "ses-ah_task-rest_run-1"
@@ -53,3 +58,86 @@ def test_get_subject_lists():
     )
     assert len(subjects) == 1
     assert subjects[0] == "01"
+
+
+def test_output_filename():
+    source_file = "sub-01_ses-ah_task-rest_run-1_space-MNIfake_res-2_desc-preproc_bold.nii.gz"
+    atlas = "fake"
+    atlas_desc = "100"
+    strategy = "simple"
+
+    generated_target = utils.output_filename(
+        source_file=source_file,
+        atlas=atlas,
+        suffix="timeseries",
+        extension="tsv",
+        strategy=strategy,
+        atlas_desc=atlas_desc,
+    )
+    assert (
+        "sub-01_ses-ah_task-rest_run-1_seg-fake100_desc-denoiseSimple_timeseries.tsv"
+        == generated_target
+    )
+
+    generated_target = utils.output_filename(
+        source_file=source_file,
+        atlas=atlas,
+        suffix="timeseries",
+        extension="json",
+        strategy=strategy,
+        atlas_desc=atlas_desc,
+    )
+    assert (
+        "sub-01_ses-ah_task-rest_run-1_desc-denoiseSimple_timeseries.json"
+        == generated_target
+    )
+
+    generated_target = utils.output_filename(
+        source_file=source_file,
+        atlas=atlas,
+        suffix="relmat",
+        extension="tsv",
+        strategy=strategy,
+        atlas_desc=atlas_desc,
+    )
+    assert (
+        "sub-01_ses-ah_task-rest_run-1_seg-fake100_meas-PearsonCorrelation_desc-denoiseSimple_relmat.tsv"
+        == generated_target
+    )
+
+    generated_target = utils.output_filename(
+        source_file=source_file,
+        atlas=atlas,
+        suffix="report",
+        extension="html",
+        strategy=strategy,
+        atlas_desc=atlas_desc,
+    )
+    assert (
+        "sub-01_ses-ah_task-rest_run-1_seg-fake100_desc-denoiseSimple_report.html"
+        == generated_target
+    )
+
+    source_file = "sub-01_ses-ah_task-rest_run-1_space-MNIfake_res-2_desc-brain_mask.nii.gz"
+
+    generated_target = utils.output_filename(
+        source_file=source_file,
+        atlas=atlas,
+        suffix="dseg",
+        extension="nii.gz",
+        strategy="",
+        atlas_desc=atlas_desc,
+    )
+    assert "sub-01_seg-fake100_dseg.nii.gz" == generated_target
+
+    generated_target = utils.output_filename(
+        source_file=source_file,
+        atlas="",
+        suffix="mask",
+        extension="nii.gz",
+        strategy="",
+        atlas_desc="",
+    )
+    assert (
+        "sub-01_space-MNIfake_res-2_label-GM_mask.nii.gz" == generated_target
+    )

--- a/giga_connectome/tests/test_utils.py
+++ b/giga_connectome/tests/test_utils.py
@@ -60,84 +60,60 @@ def test_get_subject_lists():
     assert subjects[0] == "01"
 
 
-def test_output_filename():
+@pytest.mark.parametrize(
+    "suffix,extension,target",
+    [
+        (
+            "timeseries",
+            "tsv",
+            "sub-01_ses-ah_task-rest_run-1_seg-fake100_desc-denoiseSimple_timeseries.tsv",
+        ),
+        (
+            "timeseries",
+            "json",
+            "sub-01_ses-ah_task-rest_run-1_desc-denoiseSimple_timeseries.json",
+        ),
+        (
+            "relmat",
+            "tsv",
+            "sub-01_ses-ah_task-rest_run-1_seg-fake100_meas-PearsonCorrelation_desc-denoiseSimple_relmat.tsv",
+        ),
+        (
+            "report",
+            "html",
+            "sub-01_ses-ah_task-rest_run-1_seg-fake100_desc-denoiseSimple_report.html",
+        ),
+    ],
+)
+def test_output_filename(suffix, extension, target):
     source_file = "sub-01_ses-ah_task-rest_run-1_space-MNIfake_res-2_desc-preproc_bold.nii.gz"
-    atlas = "fake"
-    atlas_desc = "100"
-    strategy = "simple"
 
     generated_target = utils.output_filename(
         source_file=source_file,
-        atlas=atlas,
-        suffix="timeseries",
-        extension="tsv",
-        strategy=strategy,
-        atlas_desc=atlas_desc,
+        atlas="fake",
+        suffix=suffix,
+        extension=extension,
+        strategy="simple",
+        atlas_desc="100",
     )
-    assert (
-        "sub-01_ses-ah_task-rest_run-1_seg-fake100_desc-denoiseSimple_timeseries.tsv"
-        == generated_target
-    )
+    assert target == generated_target
 
-    generated_target = utils.output_filename(
-        source_file=source_file,
-        atlas=atlas,
-        suffix="timeseries",
-        extension="json",
-        strategy=strategy,
-        atlas_desc=atlas_desc,
-    )
-    assert (
-        "sub-01_ses-ah_task-rest_run-1_desc-denoiseSimple_timeseries.json"
-        == generated_target
-    )
 
-    generated_target = utils.output_filename(
-        source_file=source_file,
-        atlas=atlas,
-        suffix="relmat",
-        extension="tsv",
-        strategy=strategy,
-        atlas_desc=atlas_desc,
-    )
-    assert (
-        "sub-01_ses-ah_task-rest_run-1_seg-fake100_meas-PearsonCorrelation_desc-denoiseSimple_relmat.tsv"
-        == generated_target
-    )
-
-    generated_target = utils.output_filename(
-        source_file=source_file,
-        atlas=atlas,
-        suffix="report",
-        extension="html",
-        strategy=strategy,
-        atlas_desc=atlas_desc,
-    )
-    assert (
-        "sub-01_ses-ah_task-rest_run-1_seg-fake100_desc-denoiseSimple_report.html"
-        == generated_target
-    )
-
+@pytest.mark.parametrize(
+    "atlas,atlas_desc,suffix,target",
+    [
+        ("fake", "100", "dseg", "sub-01_seg-fake100_dseg.nii.gz"),
+        ("", "", "mask", "sub-01_space-MNIfake_res-2_label-GM_mask.nii.gz"),
+    ],
+)
+def test_output_filename_seg(atlas, atlas_desc, suffix, target):
     source_file = "sub-01_ses-ah_task-rest_run-1_space-MNIfake_res-2_desc-brain_mask.nii.gz"
-
     generated_target = utils.output_filename(
         source_file=source_file,
         atlas=atlas,
-        suffix="dseg",
+        suffix=suffix,
         extension="nii.gz",
         strategy="",
         atlas_desc=atlas_desc,
     )
-    assert "sub-01_seg-fake100_dseg.nii.gz" == generated_target
-
-    generated_target = utils.output_filename(
-        source_file=source_file,
-        atlas="",
-        suffix="mask",
-        extension="nii.gz",
-        strategy="",
-        atlas_desc="",
-    )
-    assert (
-        "sub-01_space-MNIfake_res-2_label-GM_mask.nii.gz" == generated_target
-    )
+    assert target == generated_target

--- a/giga_connectome/workflow.py
+++ b/giga_connectome/workflow.py
@@ -37,7 +37,7 @@ def workflow(args: argparse.Namespace) -> None:
     # set file paths
     bids_dir = args.bids_dir
     output_dir = args.output_dir
-    working_dir = args.work_dir
+    atlases_dir = args.atlases_dir
     standardize = True  # always standardising the time series
     smoothing_fwhm = args.smoothing_fwhm
     calculate_average_correlation = (
@@ -54,7 +54,7 @@ def workflow(args: argparse.Namespace) -> None:
 
     # check output path
     output_dir.mkdir(parents=True, exist_ok=True)
-    working_dir.mkdir(parents=True, exist_ok=True)
+    atlases_dir.mkdir(parents=True, exist_ok=True)
 
     # get template information; currently we only support the fmriprep defaults
     template = (
@@ -80,7 +80,7 @@ def workflow(args: argparse.Namespace) -> None:
             [subject], template, bids_dir, args.reindex_bids, bids_filters
         )
         subject_mask_nii, subject_seg_niis = generate_gm_mask_atlas(
-            working_dir, atlas, template, subj_data["mask"]
+            atlases_dir, atlas, template, subj_data["mask"]
         )
 
         gc_log.info(f"Generate subject level connectomes: sub-{subject}")

--- a/giga_connectome/workflow.py
+++ b/giga_connectome/workflow.py
@@ -79,7 +79,7 @@ def workflow(args: argparse.Namespace) -> None:
         subj_data, _ = utils.get_bids_images(
             [subject], template, bids_dir, args.reindex_bids, bids_filters
         )
-        group_mask, resampled_atlases = generate_gm_mask_atlas(
+        subject_mask_nii, subject_seg_niis = generate_gm_mask_atlas(
             working_dir, atlas, template, subj_data["mask"]
         )
 
@@ -88,9 +88,9 @@ def workflow(args: argparse.Namespace) -> None:
         run_postprocessing_dataset(
             strategy,
             atlas,
-            resampled_atlases,
+            subject_seg_niis,
             subj_data["bold"],
-            group_mask,
+            subject_mask_nii,
             standardize,
             smoothing_fwhm,
             output_dir,


### PR DESCRIPTION
Closes #143.

- Make the working dir output follow the atlas etc convention
- `--working-dir` -> `--atlases-dir`
- Drop `space`, `res`, `atlas` in the outputs and replace with `seg` 
- `Schaefer20187Networks` -> `Schaefer2018` for simplicity.

It would be useful if someone (also know as Chris or Oscar) can have a look at the output layout in the documentation (`docs/source/outputs.md`) to make sure it makes sense. I can make sure I change the code accordingly.

## To-do

 - [x] Depreciation warning of CLI