### PR TITLE
FIX Address the case of no volumes to scrub when given the scrubbing strategy

### DIFF
--- a/giga_connectome/denoise.py
+++ b/giga_connectome/denoise.py
@@ -153,11 +153,9 @@ def denoise_meta_data(strategy: STRATEGY_TYPE, img: str) -> METADATA_TYPE:
         if sample_mask_non_steady is not None
         else 0
     )
-    n_scrub = 0
-    if "scrubbing" in strategy["parameters"].get(
-        "denoise_strategy", ""
-    ) or "srub" in strategy["parameters"].get("strategy", []):
-        n_scrub = cf.shape[0] - sm.shape[0] - n_non_steady
+    # sample mask = \
+    #   number of scan - scrubbed volumes - non steady states
+    n_scrub = 0 if sm is None else cf.shape[0] - sm.shape[0] - n_non_steady
 
     meta_data: METADATA_TYPE = {
         "ConfoundRegressors": cf.columns.tolist(),

--- a/giga_connectome/tests/test_denoise.py
+++ b/giga_connectome/tests/test_denoise.py
@@ -13,7 +13,6 @@ def test_denoise_nifti_voxel():
         strategy=strategy,
         img=img_file,
     )
-
     assert len(meta_data["ConfoundRegressors"]) == 36
     assert meta_data["NumberOfVolumesDiscardedByMotionScrubbing"] == 12
     assert meta_data["NumberOfVolumesDiscardedByNonsteadyStatesDetector"] == 2
@@ -26,11 +25,9 @@ def test_denoise_nifti_voxel():
         strategy=strategy,
         img=img_file,
     )
-
     assert len(meta_data["ConfoundRegressors"]) == 30
     assert meta_data["NumberOfVolumesDiscardedByMotionScrubbing"] == 0
     assert meta_data["NumberOfVolumesDiscardedByNonsteadyStatesDetector"] == 2
     testing.assert_almost_equal(
         meta_data["MeanFramewiseDisplacement"], 0.107, decimal=3
     )
-    print(type(meta_data["NumberOfVolumesDiscardedByMotionScrubbing"]))


### PR DESCRIPTION
A data set can have data where non steady volumes were not present and no volumes scrubbed. 

This was detected from running on ds000228.

Bug introduced by #144 