### PR TITLE
[ENH] set pybids config

### DIFF
--- a/giga_connectome/tests/test_utils.py
+++ b/giga_connectome/tests/test_utils.py
@@ -4,6 +4,9 @@ import pytest
 from bids.tests import get_test_data_path
 from pkg_resources import resource_filename
 
+from nilearn._utils.data_gen import create_fake_bids_dataset
+
+
 from giga_connectome import utils
 
 
@@ -135,3 +138,20 @@ def test_output_filename_seg(source_file, atlas, atlas_desc, suffix, target):
         atlas_desc=atlas_desc,
     )
     assert target == generated_target
+
+
+def test_desc_entity_recognised(tmp_path):
+
+    create_fake_bids_dataset(tmp_path, n_sub=1, n_ses=1, n_runs=[1, 1])
+
+    subjects = ["01"]
+    template = "MNI"
+    reindex_bids = True
+
+    utils.get_bids_images(
+        subjects,
+        template,
+        tmp_path / "bids_dataset" / "derivatives",
+        reindex_bids,
+        bids_filters=None,
+    )

--- a/giga_connectome/utils.py
+++ b/giga_connectome/utils.py
@@ -43,6 +43,7 @@ def get_bids_images(
         validate=False,
         derivatives=False,
         reset_database=reindex_bids,
+        config=["bids", "derivatives"],
     )
 
     layout_get_kwargs = {


### PR DESCRIPTION
In rare instances you can get the following puzzling crash.

Brought to my attention by @victoris93

```python
Traceback (most recent call last):
  File "/usr/local/bin/giga_connectome", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.9/site-packages/giga_connectome/run.py", line 127, in main
    workflow(args)
  File "/usr/local/lib/python3.9/site-packages/giga_connectome/workflow.py", line 81, in workflow
    subj_data, _ = utils.get_bids_images(
  File "/usr/local/lib/python3.9/site-packages/giga_connectome/utils.py", line 81, in get_bids_images
    subj_data = {
  File "/usr/local/lib/python3.9/site-packages/giga_connectome/utils.py", line 82, in <dictcomp>
    dtype: layout.get(**layout_get_kwargs, **query)
  File "/usr/local/lib/python3.9/site-packages/bids/layout/layout.py", line 629, in get
    raise ValueError(msg + "If you're sure you want to impose "
ValueError: 'desc' is not a recognized entity. If you're sure you want to impose this constraint, set invalid_filters='allow'.
```

This PR adds a regression test (uses nilearn generate fake bids data function for set up) and a fix of the pybids config to solve the issue.