### PR TITLE
FIX use types-setuptools as types-all is deprecated

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dev = [
   "giga_connectome[test]",
   'tox',
   'mypy',
-  'types-all',
+  'types-setuptools',
   'pandas-stubs',
   'types-tqdm'
 ]


### PR DESCRIPTION
Closes #184 

@jdkent Please let me know if this is good!