### PR TITLE
[ENH] Add CI workflow for creating/updating a Boutiques descriptor

### DIFF
--- a/.github/workflows/descriptor.yml
+++ b/.github/workflows/descriptor.yml
@@ -32,4 +32,4 @@ jobs:
         parser-location: giga_connectome.run:global_parser
         output-path: descriptor.json
         open-pr: true
-        token: ${{ secrets.PAT }}
+        token: ${{ secrets.PR_ACCESS }}

--- a/.github/workflows/descriptor.yml
+++ b/.github/workflows/descriptor.yml
@@ -1,0 +1,35 @@
+---
+name: Add/update Boutiques descriptor
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+
+  create-descriptor:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+
+    - name: Install package
+      run: |
+        pip install -U pip
+        pip install .
+
+    - name: Create descriptor
+      uses: michellewang/python-cli-to-boutiques@v1
+      with:
+        parser-type: argparse
+        parser-location: giga_connectome.run:global_parser
+        output-path: descriptor.json
+        open-pr: true
+        token: ${{ secrets.PAT }}


### PR DESCRIPTION
The descriptor is dumped to `descriptor.json` in the root directory.

This needs a token (e.g. PAT or GitHub App) with "write" permission for "content" and "pull request"